### PR TITLE
Rename Gateway to Controller

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 You only need to install [Go](https://go.dev/doc/install) 1.19+ to compile the project locally. Also, you need to have access to the [morty-faas/controller](https://github.com/morty-faas/controller) repository with your account.
 
-Now, you can run the following command to compile the project : 
+Now, you can run the following command to compile the project :
 
 ```bash
 go build -o morty main.go
@@ -17,9 +17,6 @@ You should now be able to use your CLI :
 
 # Output
 Name         : localhost
-Gateway URL  : http://localhost:8080
+Controller URL  : http://localhost:8080
 Registry URL : http://localhost:8081
 ```
-
-
-

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The Morty CLI is an interface allowing developers or users to easily interact wi
 
 First, you need to install the Morty CLI using one of the following methods:
 
-- Use the following command to install the latest version of the CLI : 
-`curl -fsSL https://morty-faas.github.io/install-cli.sh | sudo sh`
+- Use the following command to install the latest version of the CLI :
+  `curl -fsSL https://morty-faas.github.io/install-cli.sh | sudo sh`
 - Download a pre-compiled binary from the [releases](https://github.com/morty-faas/cli/releases) page
 - Build it from source, please see the [CONTRIBUTING.md](./CONTRIBUTING.md#compile-from-source)
 
-Once you have your Morty CLI installed locally (for the rest of the commands, we assume that `morty` is available in your `$PATH`), you can list the available runtimes and choose the more appropriate for your first function : 
+Once you have your Morty CLI installed locally (for the rest of the commands, we assume that `morty` is available in your `$PATH`), you can list the available runtimes and choose the more appropriate for your first function :
 
 ```bash
 morty runtime ls
@@ -25,7 +25,7 @@ Available runtimes:
 - rust-1.67
 ```
 
-Here we will use the `node-19` runtime to create our first function : 
+Here we will use the `node-19` runtime to create our first function :
 
 ```bash
 morty function init --runtime node-19 hello-morty
@@ -33,14 +33,14 @@ morty function init --runtime node-19 hello-morty
 morty fn init -r node-19 hello-morty
 ```
 
-You should now have a directory `hello-morty` in your current directory that contains a function code example. 
+You should now have a directory `hello-morty` in your current directory that contains a function code example.
 
-Once your function is ready, you will need to build it before invocating it. To do that, you need to have access to a Morty FaaS instance. Please refer to the [General Documentation(TODO)](#) to learn how to run a local Morty FaaS instance. For the sake of simplicity here, we will assume that we have a Morty Gateway running on `https://faas.morty.io` and a Morty Registry running on `https://registry.morty.io`, but you can use your own values.
+Once your function is ready, you will need to build it before invocating it. To do that, you need to have access to a Morty FaaS instance. Please refer to the [General Documentation(TODO)](#) to learn how to run a local Morty FaaS instance. For the sake of simplicity here, we will assume that we have a Morty Controller running on `https://faas.morty.io` and a Morty Registry running on `https://registry.morty.io`, but you can use your own values.
 
-You need first to configure your context: 
+You need first to configure your context:
 
 ```bash
-morty config add-context morty-faas --gateway https://faas.morty.io --registry https://registry.morty.io
+morty config add-context morty-faas --controller https://faas.morty.io --registry https://registry.morty.io
 # Output
 Success ! Your context 'morty-faas' has been saved and it is now the active context.
 ```
@@ -51,11 +51,12 @@ You can now build your function (it can take some time to complete) :
 
 ```bash
 morty fn build hello-morty
-# Once done, you should see something like : 
+# Once done, you should see something like :
 Function hello-morty has been created !
 ```
 
-Finally, you can invoke your function using the following command : 
+Finally, you can invoke your function using the following command :
+
 ```bash
 morty fn invoke hello-morty
 ```
@@ -70,17 +71,17 @@ Morty CLI has the ability to work with multiple contexts. By default, Morty will
 
 ```
 Name         : localhost
-Gateway URL  : http://localhost:8080
+Controller URL  : http://localhost:8080
 Registry URL : http://localhost:8081
 ```
 
 To add your own context, use the following command :
 
 ```bash
-morty config add-context $CONTEXT_NAME --gateway=$GATEWAY --registry=$REGISTRY
+morty config add-context $CONTEXT_NAME --controller=$CONTROLLER --registry=$REGISTRY
 ```
 
-Replace `$CONTEXT_NAME`, `$GATEWAY`, `$REGISTRY` with your own values.
+Replace `$CONTEXT_NAME`, `$CONTROLLER`, `$REGISTRY` with your own values.
 
 To see all the contexts available in your configuration, use the following command:
 
@@ -119,14 +120,14 @@ morty config current-context
 
 # Output without MORTY_LOG set
 Name         : thomas-dev
-Gateway URL  : http://162.38.112.57:8080
+Controller URL  : http://162.38.112.57:8080
 Registry URL : http://162.38.112.57:8081
 
 # Output with MORTY_LOG
 INFO[0000] Loading configuration from path: /Users/thomas/.morty/config.yaml
 INFO[0000] Active context : thomas-dev
 Name         : thomas-dev
-Gateway URL  : http://162.38.112.57:8080
+Controller URL  : http://162.38.112.57:8080
 Registry URL : http://162.38.112.57:8081
 ```
 
@@ -157,13 +158,14 @@ morty function build $FUNCTION_DIRECTORY
 ## Invoke a function
 
 Once your function has been built, you can invoke it through the CLI. We assume here that you have a function `hello-world` already built in the system that produces a JSON output :
+
 ```json
 {
-    "output": "Hello from my Hello World function"
+  "output": "Hello from my Hello World function"
 }
 ```
 
-To invoke your function, simply run : 
+To invoke your function, simply run :
 
 ```bash
 morty fn invoke hello-world
@@ -174,7 +176,7 @@ morty fn invoke hello-world
 }
 ```
 
-You can call your function with parameters by using the `--param` flag : 
+You can call your function with parameters by using the `--param` flag :
 
 ```bash
 morty fn invoke --param name=Morty hello-world
@@ -189,21 +191,20 @@ By default, the command will send an HTTP `GET` request on the function endpoint
 
 If you want to invoke your function with a different method, with a body or custom headers, you can use the flags of the `invoke` command :
 
-For example, to send a `POST` request with data for your function : 
+For example, to send a `POST` request with data for your function :
 
 ```
 morty fn invoke -X POST -d '{"foo":"bar"}' hello-world
 ```
 
-To add custom headers to the request, for example to precise the `Content-Type` header, use the following command : 
+To add custom headers to the request, for example to precise the `Content-Type` header, use the following command :
 
 ```
 morty fn invoke -X POST -d '{"foo":"bar"}' -H "Content-Type: application/json" hello-world
 ```
 
-For other methods or flags, use the command help : 
+For other methods or flags, use the command help :
 
 ```
 morty fn invoke --help
 ```
-

--- a/cliconfig/context.go
+++ b/cliconfig/context.go
@@ -15,7 +15,7 @@ import (
 
 type CtxKey struct{}
 type CurrentCtxKey struct{}
-type GatewayClientContextKey struct{}
+type ControllerClientContextKey struct{}
 
 const (
 	mortyConfigDefaultLocation = "$HOME/.morty/config.yaml"
@@ -41,8 +41,8 @@ type (
 	Context struct {
 		// The name of the current context
 		Name string `yaml:"name"`
-		// The address of the gateway
-		Gateway string `yaml:"gateway"`
+		// The address of the controller
+		Controller string `yaml:"controller"`
 		// The address of the registry
 		Registry string `yaml:"registry"`
 	}
@@ -79,7 +79,7 @@ func (c *Config) AddContext(context *Context) error {
 		return ErrContextAlreadyExistsWithName
 	}
 
-	context.Gateway = sanitizeUrl(context.Gateway)
+	context.Controller = sanitizeUrl(context.Controller)
 	context.Registry = sanitizeUrl(context.Registry)
 
 	c.Contexts = append(c.Contexts, *context)
@@ -103,9 +103,9 @@ func defaultConfig() *Config {
 		Current:  "localhost",
 		Contexts: []Context{
 			{
-				Name:     "localhost",
-				Gateway:  "http://localhost:8080",
-				Registry: "http://localhost:8081",
+				Name:       "localhost",
+				Controller: "http://localhost:8080",
+				Registry:   "http://localhost:8081",
 			},
 		},
 	}

--- a/cliconfig/context_test.go
+++ b/cliconfig/context_test.go
@@ -30,9 +30,9 @@ func Test_Load_ReturnUserProvidedConfigFromDefaultLocation(t *testing.T) {
 		location: location,
 		Contexts: []Context{
 			{
-				Name:     "test",
-				Gateway:  "http://gateway.morty.test",
-				Registry: "http://registry.morty.test",
+				Name:       "test",
+				Controller: "http://controller.morty.test",
+				Registry:   "http://registry.morty.test",
 			},
 		},
 	}
@@ -56,9 +56,9 @@ func Test_hasContext(t *testing.T) {
 func Test_UseContext(t *testing.T) {
 	config := defaultConfig()
 	config.Contexts = append(config.Contexts, Context{
-		Name:     "test",
-		Gateway:  "test",
-		Registry: "test",
+		Name:       "test",
+		Controller: "test",
+		Registry:   "test",
 	})
 
 	assert.True(t, config.hasContext("localhost"))
@@ -70,9 +70,9 @@ func Test_UseContext(t *testing.T) {
 
 func Test_GetContext(t *testing.T) {
 	expected := Context{
-		Name:     "test",
-		Gateway:  "test",
-		Registry: "test",
+		Name:       "test",
+		Controller: "test",
+		Registry:   "test",
 	}
 
 	config := defaultConfig()
@@ -86,9 +86,9 @@ func Test_GetContext(t *testing.T) {
 
 func Test_GetCurrentContext(t *testing.T) {
 	expected := Context{
-		Name:     "test",
-		Gateway:  "test",
-		Registry: "test",
+		Name:       "test",
+		Controller: "test",
+		Registry:   "test",
 	}
 
 	config := defaultConfig()
@@ -103,9 +103,9 @@ func Test_GetCurrentContext(t *testing.T) {
 
 func Test_AddContext(t *testing.T) {
 	expected := Context{
-		Name:     "test",
-		Gateway:  "test",
-		Registry: "test",
+		Name:       "test",
+		Controller: "test",
+		Registry:   "test",
 	}
 
 	config := defaultConfig()

--- a/cmd/config/add-context.go
+++ b/cmd/config/add-context.go
@@ -19,17 +19,17 @@ var addContextCmd = &cobra.Command{
 		name := args[0]
 
 		registry, _ := cmd.Flags().GetString("registry")
-		gateway, _ := cmd.Flags().GetString("gateway")
+		controller, _ := cmd.Flags().GetString("controller")
 
 		cfg := cmd.Context().Value(cliconfig.CtxKey{}).(*cliconfig.Config)
 
 		ctx := &cliconfig.Context{
-			Name:     name,
-			Gateway:  gateway,
-			Registry: registry,
+			Name:       name,
+			Controller: controller,
+			Registry:   registry,
 		}
 
-		log.Debugf("Adding context '%s' (gateway: %s, registry: %s)", name, gateway, registry)
+		log.Debugf("Adding context '%s' (controller: %s, registry: %s)", name, controller, registry)
 
 		// We add the context to our configuration and we set it to the current context
 		// before saving the configuration on disk.
@@ -52,6 +52,6 @@ var addContextCmd = &cobra.Command{
 }
 
 func init() {
-	addContextCmd.PersistentFlags().String("gateway", "http://localhost:8080", "The URL of the Morty instance gateway.")
+	addContextCmd.PersistentFlags().String("controller", "http://localhost:8080", "The URL of the Morty instance controller.")
 	addContextCmd.PersistentFlags().String("registry", "http://localhost:8081", "The URL of the Morty instance registry.")
 }

--- a/cmd/config/current-context.go
+++ b/cmd/config/current-context.go
@@ -20,9 +20,9 @@ var currentContextCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Name         : %s\n", ctx.Name)
-		fmt.Printf("Gateway URL  : %s\n", ctx.Gateway)
-		fmt.Printf("Registry URL : %s\n", ctx.Registry)
+		fmt.Printf("Name            : %s\n", ctx.Name)
+		fmt.Printf("Controller URL  : %s\n", ctx.Controller)
+		fmt.Printf("Registry URL    : %s\n", ctx.Registry)
 
 		return nil
 	},

--- a/cmd/config/list-context.go
+++ b/cmd/config/list-context.go
@@ -16,9 +16,9 @@ var listContextCmd = &cobra.Command{
 		cfg := cmd.Context().Value(cliconfig.CtxKey{}).(*cliconfig.Config)
 
 		for i, c := range cfg.Contexts {
-			fmt.Printf("Name         : %s\n", c.Name)
-			fmt.Printf("Gateway URL  : %s\n", c.Gateway)
-			fmt.Printf("Registry URL : %s\n", c.Registry)
+			fmt.Printf("Name            : %s\n", c.Name)
+			fmt.Printf("Controller URL  : %s\n", c.Controller)
+			fmt.Printf("Registry URL    : %s\n", c.Registry)
 
 			if i < len(cfg.Contexts)-1 {
 				fmt.Printf("\n")

--- a/cmd/function/build.go
+++ b/cmd/function/build.go
@@ -35,7 +35,7 @@ var buildCmd = &cobra.Command{
 		ctx := cmdContext.Value(cliconfig.CurrentCtxKey{}).(*cliconfig.Context)
 
 		// Initialize clients
-		client := cmdContext.Value(cliconfig.GatewayClientContextKey{}).(*morty.APIClient)
+		client := cmdContext.Value(cliconfig.ControllerClientContextKey{}).(*morty.APIClient)
 		reg := registry.NewClient(ctx.Registry)
 
 		path := "."

--- a/cmd/function/invoke.go
+++ b/cmd/function/invoke.go
@@ -118,7 +118,7 @@ func validateHttpMethod(method string) error {
 func invoke(ctx context.Context, opts *invokeOptions) (string, error) {
 	// Create an HTTP client that can interact with our Morty backend
 	currentCtx := ctx.Value(cliconfig.CurrentCtxKey{}).(*cliconfig.Context)
-	cl := httpclient.NewClient(currentCtx.Gateway)
+	cl := httpclient.NewClient(currentCtx.Controller)
 
 	log.Debugf("New invocation request with options: %v", debug.JSON(opts))
 

--- a/cmd/function/list.go
+++ b/cmd/function/list.go
@@ -20,7 +20,7 @@ var listCmd = &cobra.Command{
 	Long:    "List functions",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmdContext := cmd.Context()
-		client := cmdContext.Value(cliconfig.GatewayClientContextKey{}).(*morty.APIClient)
+		client := cmdContext.Value(cliconfig.ControllerClientContextKey{}).(*morty.APIClient)
 
 		functions, res, err := client.FunctionApi.GetFunctions(cmdContext).Execute()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ var RootCmd = &cobra.Command{
 
 		ctx := context.WithValue(cmd.Context(), cliconfig.CtxKey{}, cfg)
 		ctx = context.WithValue(ctx, cliconfig.CurrentCtxKey{}, currentCtx)
-		ctx = context.WithValue(ctx, cliconfig.GatewayClientContextKey{}, makeMortyClient(currentCtx.Gateway))
+		ctx = context.WithValue(ctx, cliconfig.ControllerClientContextKey{}, makeMortyClient(currentCtx.Controller))
 
 		cmd.SetContext(ctx)
 	},


### PR DESCRIPTION
This PR removes all the references to the old name of the Controller, Gateway.

**Migration Guide : **

Rename all the `gateway` attributes to `controller` in your `~/.morty/config.yaml`