### PR TITLE
Add version command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: ${{ steps.go-version.outputs.version }}
+        build_command: make build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+BUILD_DIR:=.
+
+GIT_IMPORT="github.com/morty-faas/cli/build"
+GIT_COMMIT=$$(git rev-parse --short HEAD)
+GIT_TAG=$$(git describe --abbrev=0 --tags)
+
+LDFLAGS="-s -w -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT) -X $(GIT_IMPORT).Version=$(GIT_TAG)"
+
+default: build
+
+.PHONY: build
+build:
+	go build -ldflags $(LDFLAGS) -o $(BUILD_DIR)/morty main.go

--- a/build/version.go
+++ b/build/version.go
@@ -1,0 +1,8 @@
+package build
+
+var (
+	// The git commit that was compiled. Will be filled in by the compiler.
+	GitCommit string
+	// The current version of Morty
+	Version string
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ func Execute() {
 }
 
 func init() {
+	RootCmd.AddCommand(versionCmd)
 	RootCmd.AddCommand(config.RootCmd)
 	RootCmd.AddCommand(function.RootCmd)
 	RootCmd.AddCommand(runtime.RootCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/morty-faas/cli/build"
+	"github.com/morty-faas/cli/cliconfig"
+	morty "github.com/morty-faas/morty/pkg/client/controller"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get the current version of the CLI and of the Morty server of the current context.",
+	Long:  "Get the current version of the CLI and of the Morty server of the current context.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := cmd.Context().Value(cliconfig.ControllerClientContextKey{}).(*morty.APIClient)
+
+		metadata, _, err := client.ConfigurationApi.GetServerMetadata(cmd.Context()).Execute()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("CLI    : '%s' (commit: %s)\n", build.Version, build.GitCommit)
+		fmt.Printf("Server : '%s' (commit: %s)\n", metadata.GetVersion(), metadata.GetGitCommit())
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ retract (
 require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/hashicorp/go-getter v1.7.1
-	github.com/morty-faas/morty v1.1.0-RC1
+	github.com/morty-faas/morty v1.1.0-RC1.0.20230513211117-5beade79921b
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/morty-faas/morty v1.1.0-RC1 h1:Viy5y8Ghnwuf/3P0wHHjIIahNopDDQUqFFYljojoTBI=
 github.com/morty-faas/morty v1.1.0-RC1/go.mod h1:HRJ867IsYSF0dROI5eAmQjHkSI7+Trs6VSXHSV0EMtw=
+github.com/morty-faas/morty v1.1.0-RC1.0.20230513211117-5beade79921b h1:WxBl1O/VurXy3AMeZrkdLtJAtbDyvrThO02GGVRtLg0=
+github.com/morty-faas/morty v1.1.0-RC1.0.20230513211117-5beade79921b/go.mod h1:knCFikLpKsyLm9qjXseYV3ZtHQtfXuTNSOm7thTeejk=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=


### PR DESCRIPTION
This PR brings the following improvements : 

- New command `morty version` that displays information about version of the CLI and the Morty server:

```bash
morty version

# Example output
CLI   : 'v1.2.0-RC1' (commit: 529f985)
Server: 'v1.1.0-RC1' (commit: ca3e414)
```